### PR TITLE
Fixed bug where larger numbers caused errors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,8 @@ Please answer the questions by inserting a numerical value after the ":" symbol 
 5. ways to access/modify databases:
 6. global variables:
 7. dependencies:
-8. classes/modules
-9. privileges
+8. classes/modules:
+9. privileges:
 10. - [ ] None of the above
 
 
@@ -26,8 +26,8 @@ Please answer the questions by inserting a numerical value after the ":" symbol 
 5. ways to access/modify databases:
 6. global variables:
 7. dependencies:
-8. classes/modules
-9. privileges
+8. classes/modules:
+9. privileges:
 10. - [ ] None of the above
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8587,7 +8587,7 @@ const extractData = (question_body) => {
   core.debug(lines)
 
   // Only keep the questions
-  const regex = /^\d\..*/
+  const regex = /^\d{1,3}\..*/
   let filtered = lines.filter((line) => line.match(regex))
   core.debug('\u001b[38;5;6mThe question lines:')
   core.debug(filtered)
@@ -8736,6 +8736,7 @@ const main = async () => {
 
       core.debug('\u001b[38;5;6mAll questions are answered: ')
       core.debug(response)
+      core.info('The answers: ', response)
 
       createSqlFiles(
         response,

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const extractData = (question_body) => {
   core.debug(lines)
 
   // Only keep the questions
-  const regex = /^\d\..*/
+  const regex = /^\d{1,3}\..*/
   let filtered = lines.filter((line) => line.match(regex))
   core.debug('\u001b[38;5;6mThe question lines:')
   core.debug(filtered)


### PR DESCRIPTION
Fix a bug  where numbers larger than 9 wasnt read. 
Also added some missing colons


<!--Begin questions-->
## Questions:
Please answer the questions by inserting a numerical value after the ":" symbol or check the "None of the above"-option.

**I have created/added/opened/granted new:**
1. APIs/Ports:
2. ways to receive user input:
3. databases:
4. storing new user data:
5. ways to access/modify databases:
6. global variables:
7. dependencies:
8. classes/modules:
9. privileges:
10. - [x] None of the above


**I have modified:**
1. APIs/Ports:
2. ways to receive user input:
4. databases:
5. ways to access/modify databases:
6. global variables:
7. dependencies:
8. classes/modules:
9. privileges:
10. - [x] None of the above



- [x] I have filled in the questions above :heavy_exclamation_mark:
<!--End of questions-->
